### PR TITLE
Reduce memory consumption by avoiding circular reference from stream reader

### DIFF
--- a/src/ProxyConnector.php
+++ b/src/ProxyConnector.php
@@ -134,14 +134,11 @@ class ProxyConnector implements ConnectorInterface
 
             // keep buffering data until headers are complete
             $buffer = '';
-            $fn = function ($chunk) use (&$buffer, &$fn, $deferred, $stream) {
+            $fn = function ($chunk) use (&$buffer, $deferred, $stream) {
                 $buffer .= $chunk;
 
                 $pos = strpos($buffer, "\r\n\r\n");
                 if ($pos !== false) {
-                    // end of headers received => stop buffering
-                    $stream->removeListener('data', $fn);
-
                     // try to parse headers as response message
                     try {
                         $response = Psr7\parse_response(substr($buffer, 0, $pos));
@@ -191,7 +188,10 @@ class ProxyConnector implements ConnectorInterface
 
             $stream->write("CONNECT " . $host . ":" . $port . " HTTP/1.1\r\nHost: " . $host . ":" . $port . "\r\n" . $auth . "\r\n");
 
-            return $deferred->promise();
+            return $deferred->promise()->always(function () use ($stream, $fn) {
+                // Stop buffering when connection has been established or rejected.
+                $stream->removeListener('data', $fn);
+            });
         }, function (Exception $e) use ($proxyUri) {
             throw new RuntimeException('Unable to connect to proxy (ECONNREFUSED)', defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $e);
         });

--- a/src/ProxyConnector.php
+++ b/src/ProxyConnector.php
@@ -188,9 +188,10 @@ class ProxyConnector implements ConnectorInterface
 
             $stream->write("CONNECT " . $host . ":" . $port . " HTTP/1.1\r\nHost: " . $host . ":" . $port . "\r\n" . $auth . "\r\n");
 
-            return $deferred->promise()->always(function () use ($stream, $fn) {
-                // Stop buffering when connection has been established or rejected.
+            return $deferred->promise()->then(function (ConnectionInterface $stream) use ($fn) {
+                // Stop buffering when connection has been established.
                 $stream->removeListener('data', $fn);
+                return new Promise\FulfilledPromise($stream);
             });
         }, function (Exception $e) use ($proxyUri) {
             throw new RuntimeException('Unable to connect to proxy (ECONNREFUSED)', defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $e);


### PR DESCRIPTION
Stream reader has a circular reference to itself here: https://github.com/clue/php-http-proxy-react/blob/7258a76f492357874d0af1fe1f50a08209f61174/src/ProxyConnector.php#L137 so it can be cleaned only with GC. When a proxy is doing a lot of disconnects, it is turning into a nightmare.