### PR TITLE
Improve error reporting by always including target URI in exceptions

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -32,37 +32,19 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
         $mock
             ->expects($this->once())
             ->method('__invoke')
-            ->with($this->equalTo($value));
+            ->with($value);
 
         return $mock;
     }
 
-    protected function expectCallableOnceWithExceptionCode($code)
+    protected function expectCallableOnceWithException($class, $message, $code)
     {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Exception'),
-                $this->callback(function ($e) use ($code) {
-                    return $e->getCode() === $code;
-                })
-            ));
-
-        return $mock;
-    }
-
-
-    protected function expectCallableOnceParameter($type)
-    {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->isInstanceOf($type));
-
-        return $mock;
+        return $this->expectCallableOnceWith($this->logicalAnd(
+            $this->isInstanceOf($class),
+            $this->callback(function (\Exception $e) use ($message, $code) {
+                return strpos($e->getMessage(), $message) !== false && $e->getCode() === $code;
+            })
+        ));
     }
 
     /**

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -34,7 +34,11 @@ class FunctionalTest extends AbstractTestCase
 
         $promise = $proxy->connect('google.com:80');
 
-        $this->setExpectedException('RuntimeException', 'Unable to connect to proxy', SOCKET_ECONNREFUSED);
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tcp://google.com:80 failed because connection to proxy failed (ECONNREFUSED)',
+            SOCKET_ECONNREFUSED
+        );
         Block\await($promise, $this->loop, 3.0);
     }
 
@@ -44,7 +48,11 @@ class FunctionalTest extends AbstractTestCase
 
         $promise = $proxy->connect('google.com:80');
 
-        $this->setExpectedException('RuntimeException', '405 (Method Not Allowed)', SOCKET_ECONNREFUSED);
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tcp://google.com:80 failed because proxy refused connection with HTTP error code 405 (Method Not Allowed) (ECONNREFUSED)',
+            SOCKET_ECONNREFUSED
+        );
         Block\await($promise, $this->loop, 3.0);
     }
 
@@ -59,7 +67,11 @@ class FunctionalTest extends AbstractTestCase
 
         $promise = $proxy->connect('google.com:80');
 
-        $this->setExpectedException('RuntimeException', '405 (Method Not Allowed)', SOCKET_ECONNREFUSED);
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tcp://google.com:80 failed because proxy refused connection with HTTP error code 405 (Method Not Allowed) (ECONNREFUSED)',
+            SOCKET_ECONNREFUSED
+        );
         Block\await($promise, $this->loop, 3.0);
     }
 
@@ -69,7 +81,11 @@ class FunctionalTest extends AbstractTestCase
 
         $promise = $proxy->connect('google.com:80');
 
-        $this->setExpectedException('RuntimeException', 'Connection to proxy lost', SOCKET_ECONNRESET);
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tcp://google.com:80 failed because connection to proxy was lost while waiting for response (ECONNRESET)',
+            SOCKET_ECONNRESET
+        );
         Block\await($promise, $this->loop, 3.0);
     }
 


### PR DESCRIPTION
Builds on top of #23 and https://github.com/reactphp/socket/pull/168, https://github.com/reactphp/socket/pull/169, https://github.com/reactphp/socket/pull/170, https://github.com/reactphp/socket/pull/171, https://github.com/reactphp/socket/pull/176 and https://github.com/reactphp/socket/pull/177