### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and use Number Codes if Error Constants are undefined

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -19,10 +19,9 @@ matrix:
   allow_failures:
     - php: hhvm-3.18
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^7.0 || ^5.0 || ^4.8",
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/http": "^1.0",
         "clue/block-react": "^1.1"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Http Proxy Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Http Proxy Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -52,19 +52,29 @@ abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 8.5+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8.4
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 
-    public function setExpectedException($exception, $message = '', $code = 0)
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
     {
         if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
             $this->expectException($exception);
-            if ($message !== '') {
-                $this->expectExceptionMessage($message);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
             }
-            $this->expectExceptionCode($code);
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
         } else {
-            parent::setExpectedException($exception, $message, $code);
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
         }
     }
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -40,7 +40,7 @@ class FunctionalTest extends AbstractTestCase
         $this->setExpectedException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because connection to proxy failed (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         );
         Block\await($promise, $this->loop, 3.0);
     }
@@ -54,7 +54,7 @@ class FunctionalTest extends AbstractTestCase
         $this->setExpectedException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy refused connection with HTTP error code 405 (Method Not Allowed) (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         );
         Block\await($promise, $this->loop, 3.0);
     }
@@ -73,7 +73,7 @@ class FunctionalTest extends AbstractTestCase
         $this->setExpectedException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy refused connection with HTTP error code 405 (Method Not Allowed) (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         );
         Block\await($promise, $this->loop, 3.0);
     }
@@ -87,7 +87,7 @@ class FunctionalTest extends AbstractTestCase
         $this->setExpectedException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because connection to proxy was lost while waiting for response (ECONNRESET)',
-            SOCKET_ECONNRESET
+            defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104
         );
         Block\await($promise, $this->loop, 3.0);
     }
@@ -107,18 +107,5 @@ class FunctionalTest extends AbstractTestCase
         unset($promise);
 
         $this->assertEquals(0, gc_collect_cycles());
-    }
-
-    public function setExpectedException($exception, $message = '', $code = 0)
-    {
-        if (method_exists($this, 'expectException')) {
-            $this->expectException($exception);
-            if ($message !== null) {
-                $this->expectExceptionMessage($message);
-            }
-            $this->expectExceptionCode($code);
-        } else {
-            parent::setExpectedException($exception, $message, $code);
-        }
     }
 }

--- a/tests/ProxyConnectorTest.php
+++ b/tests/ProxyConnectorTest.php
@@ -294,7 +294,7 @@ class ProxyConnectorTest extends AbstractTestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because connection to proxy failed (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
 
         $promise->then(null, $this->expectCallableOnceWith($this->callback(function (\Exception $e) use ($previous) {
@@ -319,7 +319,7 @@ class ProxyConnectorTest extends AbstractTestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy returned invalid response (EBADMSG)',
-            SOCKET_EBADMSG
+            defined('SOCKET_EBADMSG') ? SOCKET_EBADMSG: 71
         ));
     }
 
@@ -340,7 +340,7 @@ class ProxyConnectorTest extends AbstractTestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy response headers exceed maximum of 8 KiB (EMSGSIZE)',
-            SOCKET_EMSGSIZE
+            defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90
         ));
     }
 
@@ -361,7 +361,7 @@ class ProxyConnectorTest extends AbstractTestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy denied access with HTTP error code 407 (Proxy Authentication Required) (EACCES)',
-            SOCKET_EACCES
+            defined('SOCKET_EACCES') ? SOCKET_EACCES : 13
         ));
     }
 
@@ -382,7 +382,7 @@ class ProxyConnectorTest extends AbstractTestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy refused connection with HTTP error code 403 (Not allowed) (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
     }
 
@@ -402,7 +402,7 @@ class ProxyConnectorTest extends AbstractTestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because connection to proxy caused a stream error (EIO)',
-            SOCKET_EIO
+            defined('SOCKET_EIO') ? SOCKET_EIO : 5
         ));
 
         $promise->then(null, $this->expectCallableOnceWith($this->callback(function (\Exception $e) use ($previous) {
@@ -471,7 +471,7 @@ class ProxyConnectorTest extends AbstractTestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 cancelled while waiting for proxy (ECONNABORTED)',
-            SOCKET_ECONNABORTED
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
         ));
     }
 


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #34.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.4.1 by Sebastian Bergmann and contributors.

........................................                          40 / 40 (100%)

Time: 00:00.265, Memory: 8.00 MB

OK (40 tests, 82 assertions)
```