### PR TITLE
Simplify usage by supporting new Socket API without nullable loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ secure HTTPS request to google.com through a local HTTP proxy server:
 ```php
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'timeout' => 3.0,
     'dns' => false
@@ -115,7 +115,7 @@ proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'
@@ -175,7 +175,7 @@ in ReactPHP's [`Connector`](https://github.com/reactphp/socket#connector):
 ```php
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
@@ -201,7 +201,7 @@ ReactPHP's [`Connector`](https://github.com/reactphp/socket#connector):
 ```php
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
@@ -228,12 +228,12 @@ This allows you to send both plain HTTP and TLS-encrypted HTTPS requests like th
 ```php
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 
 $browser->get('https://example.com/')->then(function (Psr\Http\Message\ResponseInterface $response) {
     var_dump($response->getHeaders(), (string) $response->getBody());
@@ -263,7 +263,7 @@ underlying connection attempt if it takes too long:
 ```php
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false,
     'timeout' => 3.0
@@ -307,7 +307,7 @@ other examples explicitly disable DNS resolution like this:
 ```php
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
@@ -319,7 +319,7 @@ If you want to explicitly use *local DNS resolution*, you can use the following 
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
 // set up Connector which uses Google's public DNS (8.8.8.8)
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => '8.8.8.8'
 ));

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "require": {
         "php": ">=5.3",
         "react/promise": " ^2.1 || ^1.2.1",
-        "react/socket": "^1.8",
+        "react/socket": "^1.9",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
+        "clue/block-react": "^1.1",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8",
         "react/event-loop": "^1.2",
-        "react/http": "^1.4",
-        "clue/block-react": "^1.1"
+        "react/http": "^1.5"
     }
 }

--- a/examples/01-http-request.php
+++ b/examples/01-http-request.php
@@ -23,12 +23,12 @@ if ($url === false) {
 
 $proxy = new Clue\React\HttpProxy\ProxyConnector($url);
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 
 $browser->get('https://example.com/')->then(function (Psr\Http\Message\ResponseInterface $response) {
     var_dump($response->getHeaders(), (string) $response->getBody());

--- a/examples/02-optional-proxy-http-request.php
+++ b/examples/02-optional-proxy-http-request.php
@@ -20,14 +20,14 @@ $url = getenv('http_proxy');
 if ($url !== false) {
     $proxy = new Clue\React\HttpProxy\ProxyConnector($url);
 
-    $connector = new React\Socket\Connector(null, array(
+    $connector = new React\Socket\Connector(array(
         'tcp' => $proxy,
         'timeout' => 3.0,
         'dns' => false
     ));
 }
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 
 $browser->get('https://example.com/')->then(function (Psr\Http\Message\ResponseInterface $response) {
     var_dump($response->getHeaders(), (string) $response->getBody());

--- a/examples/11-proxy-raw-https-protocol.php
+++ b/examples/11-proxy-raw-https-protocol.php
@@ -26,7 +26,7 @@ if ($url === false) {
 
 $proxy = new Clue\React\HttpProxy\ProxyConnector($url);
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'timeout' => 3.0,
     'dns' => false

--- a/examples/12-optional-proxy-raw-https-protocol.php
+++ b/examples/12-optional-proxy-raw-https-protocol.php
@@ -26,7 +26,7 @@ $url = getenv('http_proxy');
 if ($url !== false) {
     $proxy = new Clue\React\HttpProxy\ProxyConnector($url);
 
-    $connector = new React\Socket\Connector(null, array(
+    $connector = new React\Socket\Connector(array(
         'tcp' => $proxy,
         'timeout' => 3.0,
         'dns' => false

--- a/examples/13-custom-proxy-headers.php
+++ b/examples/13-custom-proxy-headers.php
@@ -33,7 +33,7 @@ $proxy = new Clue\React\HttpProxy\ProxyConnector(
     )
 );
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'timeout' => 3.0,
     'dns' => false,

--- a/examples/21-proxy-raw-smtp-protocol.php
+++ b/examples/21-proxy-raw-smtp-protocol.php
@@ -25,7 +25,7 @@ if ($url === false) {
 
 $proxy = new Clue\React\HttpProxy\ProxyConnector($url);
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'timeout' => 3.0,
     'dns' => false

--- a/examples/22-proxy-raw-smtps-protocol.php
+++ b/examples/22-proxy-raw-smtps-protocol.php
@@ -28,7 +28,7 @@ if ($url === false) {
 
 $proxy = new Clue\React\HttpProxy\ProxyConnector($url);
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'timeout' => 3.0,
     'dns' => false

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -4,7 +4,7 @@ namespace Clue\Tests\React\HttpProxy;
 
 use PHPUnit\Framework\TestCase;
 
-abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
+abstract class AbstractTestCase extends TestCase
 {
     protected function expectCallableNever()
     {
@@ -77,6 +77,4 @@ abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
             parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
         }
     }
-
 }
-

--- a/tests/ProxyConnectorTest.php
+++ b/tests/ProxyConnectorTest.php
@@ -3,9 +3,9 @@
 namespace Clue\Tests\React\HttpProxy;
 
 use Clue\React\HttpProxy\ProxyConnector;
-use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Promise\Deferred;
+use React\Promise\Promise;
 
 class ProxyConnectorTest extends AbstractTestCase
 {


### PR DESCRIPTION
Builds on top of #41, https://github.com/reactphp/socket/pull/264 and https://github.com/reactphp/http/pull/419
Refs https://github.com/clue/reactphp-ssh-proxy/pull/28