### PR TITLE
Fix invalid references in exception stack trace

### DIFF
--- a/src/ProxyConnector.php
+++ b/src/ProxyConnector.php
@@ -256,11 +256,11 @@ class ProxyConnector implements ConnectorInterface
 
             // Exception trace arguments are not available on some PHP 7.4 installs
             // @codeCoverageIgnoreStart
-            foreach ($trace as &$one) {
+            foreach ($trace as $ti => $one) {
                 if (isset($one['args'])) {
-                    foreach ($one['args'] as &$arg) {
+                    foreach ($one['args'] as $ai => $arg) {
                         if ($arg instanceof \Closure) {
-                            $arg = 'Object(' . get_class($arg) . ')';
+                            $trace[$ti]['args'][$ai] = 'Object(' . get_class($arg) . ')';
                         }
                     }
                 }


### PR DESCRIPTION
This changeset fixes any invalid references in the exception stack trace. This is a pretty nasty bug that has been introduced a while ago with #23 that only happens on PHP 7+ when printing the exception trace (`$exception->getTraceAsString()`). This is now covered by the updated test suite and should work across all supported PHP versions.

Builds on top of https://github.com/clue/reactphp-socks/pull/104 and #23