### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Http Proxy Test Suite">
             <directory>./tests/</directory>
@@ -16,4 +17,7 @@
             <directory>./src/</directory>
         </include>
     </coverage>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>


### PR DESCRIPTION
This changeset adds support for PHP 8.1 and adds `convertDeprecationsToExceptions="true"` to the `phpunit.xml` configuration to make sure we'll see future deprecation notices.

Builds on top of #38.