### PR TITLE
Mark passwords and URIs as `#[\SensitiveParameter]` (PHP 8.2+)

### DIFF
--- a/src/ProxyConnector.php
+++ b/src/ProxyConnector.php
@@ -57,8 +57,12 @@ class ProxyConnector implements ConnectorInterface
      * @param array $httpHeaders Custom HTTP headers to be sent to the proxy.
      * @throws InvalidArgumentException if the proxy URL is invalid
      */
-    public function __construct($proxyUrl, ConnectorInterface $connector = null, array $httpHeaders = array())
-    {
+    public function __construct(
+        #[\SensitiveParameter]
+        $proxyUrl,
+        ConnectorInterface $connector = null,
+        array $httpHeaders = array()
+    ) {
         // support `http+unix://` scheme for Unix domain socket (UDS) paths
         if (preg_match('/^http\+unix:\/\/(.*?@)?(.+?)$/', $proxyUrl, $match)) {
             // rewrite URI to parse authentication from dummy host


### PR DESCRIPTION
As @clue describes in https://github.com/friends-of-reactphp/mysql/pull/162:

> This changeset marks all passwords and URIs containing passwords as `#[\SensitiveParameter]` to avoid these parameter from potentially showing up in exception traces in PHP 8.2+. Older PHP versions are not affected by this change and continue to work as is. See also RFC: https://wiki.php.net/rfc/redact_parameters_in_back_traces

Refs #48 