### PR TITLE
Update test suite to use new reactphp/async package instead of clue/reactphp-block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,11 @@
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
-        "clue/block-react": "^1.5",
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+        "react/async": "^4 || ^3 || ^2",
         "react/event-loop": "^1.2",
-        "react/http": "^1.5"
+        "react/http": "^1.5",
+        "react/promise-timer": "^1.10"
     },
     "autoload": {
         "psr-4": { 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -2,9 +2,7 @@
 
 namespace Clue\Tests\React\HttpProxy;
 
-use Clue\React\Block;
 use Clue\React\HttpProxy\ProxyConnector;
-use React\EventLoop\Loop;
 
 /** @group internet */
 class FunctionalTest extends AbstractTestCase
@@ -20,7 +18,7 @@ class FunctionalTest extends AbstractTestCase
             'Connection to tcp://google.com:80 failed because connection to proxy failed (ECONNREFUSED)',
             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         );
-        Block\await($promise, Loop::get(), 3.0);
+        \React\Async\await(\React\Promise\Timer\timeout($promise, 3.0));
     }
 
     public function testPlainGoogleDoesNotAcceptConnectMethod()
@@ -34,7 +32,7 @@ class FunctionalTest extends AbstractTestCase
             'Connection to tcp://google.com:80 failed because proxy refused connection with HTTP error code 405 (Method Not Allowed) (ECONNREFUSED)',
             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         );
-        Block\await($promise, Loop::get(), 3.0);
+        \React\Async\await(\React\Promise\Timer\timeout($promise, 3.0));
     }
 
     public function testSecureGoogleDoesNotAcceptConnectMethod()
@@ -52,7 +50,7 @@ class FunctionalTest extends AbstractTestCase
             'Connection to tcp://google.com:80 failed because proxy refused connection with HTTP error code 405 (Method Not Allowed) (ECONNREFUSED)',
             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         );
-        Block\await($promise, Loop::get(), 3.0);
+        \React\Async\await(\React\Promise\Timer\timeout($promise, 3.0));
     }
 
     public function testSecureGoogleDoesNotAcceptPlainStream()
@@ -66,7 +64,7 @@ class FunctionalTest extends AbstractTestCase
             'Connection to tcp://google.com:80 failed because connection to proxy was lost while waiting for response (ECONNRESET)',
             defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104
         );
-        Block\await($promise, Loop::get(), 3.0);
+        \React\Async\await(\React\Promise\Timer\timeout($promise, 3.0));
     }
 
     /**


### PR DESCRIPTION
This pull request is a continuation of #50 and adds [reactphp/async](https://github.com/reactphp/async) to replace the deprecated [clue/reactphp-block](https://github.com/clue/reactphp-block) dependency. Thank you @dinooo13 for doing most of the work on this! 💪

After building on top of #50, I also added [reactphp/promise-timer](https://github.com/reactphp/promise-timer) as a dev-dependency. We initially installed reactphp/promise-timer through either [reactphp/socket](https://github.com/reactphp/socket) or [reactphp/dns](https://github.com/reactphp/dns), but the ReactPHP Socket component removed its reactphp/promise-timer dependency in [`v1.13.0`](https://github.com/reactphp/socket/releases/tag/v1.13.0) and the ReactPHP DNS component did the same in [`v1.11.0`](https://github.com/reactphp/dns/releases/tag/v1.11.0).

Builds on top of #50, https://github.com/clue/reactphp-block/pull/67, https://github.com/clue/reactphp-block/issues/68, https://github.com/reactphp/http/pull/464, https://github.com/reactphp/socket/pull/305 and https://github.com/clue/reactphp-mq/pull/34

Closes #50