### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/promise": "^3 || ^2.1 || ^1.2.1",
-        "react/socket": "^1.12",
+        "react/promise": "^3.2 || ^2.1 || ^1.2.1",
+        "react/socket": "^1.16",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-        "react/async": "^4 || ^3 || ^2",
+        "react/async": "^4.3 || ^3 || ^2",
         "react/event-loop": "^1.2",
-        "react/http": "^1.5",
-        "react/promise-timer": "^1.10"
+        "react/http": "^1.11",
+        "react/promise-timer": "^1.11"
     },
     "autoload": {
         "psr-4": { 

--- a/src/ProxyConnector.php
+++ b/src/ProxyConnector.php
@@ -60,7 +60,7 @@ class ProxyConnector implements ConnectorInterface
     public function __construct(
         #[\SensitiveParameter]
         $proxyUrl,
-        ConnectorInterface $connector = null,
+        $connector = null,
         array $httpHeaders = array()
     ) {
         // support `http+unix://` scheme for Unix domain socket (UDS) paths
@@ -82,6 +82,10 @@ class ProxyConnector implements ConnectorInterface
         $parts = parse_url($proxyUrl);
         if (!$parts || !isset($parts['scheme'], $parts['host']) || ($parts['scheme'] !== 'http' && $parts['scheme'] !== 'https')) {
             throw new InvalidArgumentException('Invalid proxy URL "' . $proxyUrl . '"');
+        }
+
+        if ($connector !== null && !$connector instanceof ConnectorInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #2 ($connector) expected null|React\Socket\ConnectorInterface');
         }
 
         // apply default port and TCP/TLS transport for given scheme

--- a/tests/ProxyConnectorTest.php
+++ b/tests/ProxyConnectorTest.php
@@ -48,6 +48,12 @@ class ProxyConnectorTest extends AbstractTestCase
         new ProxyConnector('https+unix:///tmp/proxy.sock', $this->connector);
     }
 
+    public function testContructorThrowsExceptionForInvalidConnector()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($connector) expected null|React\Socket\ConnectorInterface');
+        new ProxyConnector('proxy.example.com', 'connector');
+    }
+
     public function testCreatesConnectionToHttpPort()
     {
         $promise = new Promise(function () { });


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #54, #42, #41,  https://github.com/reactphp/promise/pull/260, https://github.com/reactphp/socket/pull/318, https://github.com/reactphp/http/pull/537 and https://github.com/reactphp/async/pull/87, https://github.com/reactphp/promise-timer/pull/70.