### PR TITLE
Remove ringcentral/psr7 because it appears to be abandoned and upstream projects would like to support psr/http-message ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "require": {
         "php": ">=5.3",
         "react/promise": "^3.3 || ^2.1 || ^1.2.1",
-        "react/socket": "^1.17",
-        "ringcentral/psr7": "^1.2"
+        "react/socket": "^1.17"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",

--- a/src/ProxyConnector.php
+++ b/src/ProxyConnector.php
@@ -5,7 +5,6 @@ namespace Clue\React\HttpProxy;
 use Exception;
 use InvalidArgumentException;
 use RuntimeException;
-use RingCentral\Psr7;
 use React\Promise;
 use React\Promise\Deferred;
 use React\Socket\ConnectionInterface;
@@ -183,30 +182,30 @@ class ProxyConnector implements ConnectorInterface
                     $fn = null;
 
                     // try to parse headers as response message
-                    try {
-                        $response = Psr7\parse_response(substr($buffer, 0, $pos));
-                    } catch (Exception $e) {
+                    if (!preg_match('/^HTTP\/1\.[01] ([0-9]{3})( .*)?\r\n/', $buffer, $matches)) {
                         $deferred->reject(new RuntimeException(
                             'Connection to ' . $uri . ' failed because proxy returned invalid response (EBADMSG)',
-                            defined('SOCKET_EBADMSG') ? SOCKET_EBADMSG: 71,
-                            $e
+                            defined('SOCKET_EBADMSG') ? SOCKET_EBADMSG : 71
                         ));
                         $stream->close();
                         return;
                     }
 
-                    if ($response->getStatusCode() === 407) {
+                    $statusCode = (int) $matches[1];
+                    $reasonPhrase = isset($matches[2]) ? trim($matches[2]) : '';
+
+                    if ($statusCode === 407) {
                         // map status code 407 (Proxy Authentication Required) to EACCES
                         $deferred->reject(new RuntimeException(
-                            'Connection to ' . $uri . ' failed because proxy denied access with HTTP error code ' . $response->getStatusCode() . ' (' . $response->getReasonPhrase() . ') (EACCES)',
+                            'Connection to ' . $uri . ' failed because proxy denied access with HTTP error code ' . $statusCode . ' (' . $reasonPhrase . ') (EACCES)',
                             defined('SOCKET_EACCES') ? SOCKET_EACCES : 13
                         ));
                         $stream->close();
                         return;
-                    } elseif ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+                    } elseif ($statusCode < 200 || $statusCode >= 300) {
                         // map non-2xx status code to ECONNREFUSED
                         $deferred->reject(new RuntimeException(
-                            'Connection to ' . $uri . ' failed because proxy refused connection with HTTP error code ' . $response->getStatusCode() . ' (' . $response->getReasonPhrase() . ') (ECONNREFUSED)',
+                            'Connection to ' . $uri . ' failed because proxy refused connection with HTTP error code ' . $statusCode . ' (' . $reasonPhrase . ') (ECONNREFUSED)',
                             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
                         ));
                         $stream->close();


### PR DESCRIPTION
It is unclear if we need to wait for all of the headers before parsing or if by removing the PSR7 requirement we can simply just parse the first line of the http response. I left the `strpos()` in there in case there was a reason the code was waiting.

This resolves issue #64 