### PR TITLE
Improve PHP 8.5+ support by avoiding deprecated `setAccessible()` calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -26,7 +27,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -39,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
       - name: Run hhvm composer.phar install
         uses: docker://hhvm/hhvm:3.30-lts-latest

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/promise": "^3.2 || ^2.1 || ^1.2.1",
-        "react/socket": "^1.16",
+        "react/promise": "^3.3 || ^2.1 || ^1.2.1",
+        "react/socket": "^1.17",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",
         "react/async": "^4.3 || ^3 || ^2",
-        "react/event-loop": "^1.2",
+        "react/event-loop": "^1.6",
         "react/http": "^1.11",
         "react/promise-timer": "^1.11"
     },

--- a/src/ProxyConnector.php
+++ b/src/ProxyConnector.php
@@ -261,7 +261,9 @@ class ProxyConnector implements ConnectorInterface
             // avoid garbage references by replacing all closures in call stack.
             // what a lovely piece of code!
             $r = new \ReflectionProperty('Exception', 'trace');
-            $r->setAccessible(true);
+            if (PHP_VERSION_ID < 80100) {
+                $r->setAccessible(true);
+            }
             $trace = $r->getValue($e);
 
             // Exception trace arguments are not available on some PHP 7.4 installs

--- a/tests/ProxyConnectorTest.php
+++ b/tests/ProxyConnectorTest.php
@@ -24,7 +24,9 @@ class ProxyConnectorTest extends AbstractTestCase
         $proxy = new ProxyConnector('proxy.example.com');
 
         $ref = new \ReflectionProperty($proxy, 'connector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connector = $ref->getValue($proxy);
 
         $this->assertInstanceOf('React\Socket\ConnectorInterface', $connector);


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by avoiding the deprecated `setAccessible()` call as discussed in https://github.com/clue/framework-x/pull/297.

Builds on top of #66, https://github.com/reactphp/socket/pull/325, https://github.com/reactphp/promise/pull/264, https://github.com/reactphp/event-loop/pull/282, and https://github.com/clue/framework-x/pull/297